### PR TITLE
demo: pause once per command in guided demos

### DIFF
--- a/init-cdc/prompt.sh
+++ b/init-cdc/prompt.sh
@@ -27,6 +27,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 KC_HOST="127.0.0.1"

--- a/init-clone/prompt.sh
+++ b/init-clone/prompt.sh
@@ -23,6 +23,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-colocate/prompt.sh
+++ b/init-colocate/prompt.sh
@@ -24,6 +24,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-dsql/prompt.sh
+++ b/init-dsql/prompt.sh
@@ -20,6 +20,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-ear/prompt.sh
+++ b/init-ear/prompt.sh
@@ -21,6 +21,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 KEY_DIR="${PWD}/keys"

--- a/init-ft/prompt.sh
+++ b/init-ft/prompt.sh
@@ -10,6 +10,10 @@ WS_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "/workspaces/ybdb-va
 WS_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo "/workspaces/ybdb-vanguard")
 
 TYPE_SPEED=50
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 

--- a/init-geo/prompt.sh
+++ b/init-geo/prompt.sh
@@ -19,6 +19,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-obs/prompt.sh
+++ b/init-obs/prompt.sh
@@ -18,6 +18,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}obs_demo ${COLOR_RESET}"
 
 DB="obs_demo"

--- a/init-pitr/prompt.sh
+++ b/init-pitr/prompt.sh
@@ -16,6 +16,10 @@
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-privacy/prompt.sh
+++ b/init-privacy/prompt.sh
@@ -14,6 +14,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-qt/prompt.sh
+++ b/init-qt/prompt.sh
@@ -20,6 +20,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=90
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 run_cmd "ysqlsh -h 127.0.0.1 -X -c \"alter role yugabyte set enable_seqscan=off; analyze verbose; \""

--- a/init-rls/prompt.sh
+++ b/init-rls/prompt.sh
@@ -13,6 +13,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-scale/prompt.sh
+++ b/init-scale/prompt.sh
@@ -4,6 +4,10 @@
 set -f  # disable filename expansion — prevents SELECT * glob-expanding in eval $@
 
 TYPE_SPEED=50
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 

--- a/init-tablespace/prompt.sh
+++ b/init-tablespace/prompt.sh
@@ -31,6 +31,10 @@
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-tt/prompt.sh
+++ b/init-tt/prompt.sh
@@ -19,6 +19,10 @@
 
 TYPE_SPEED=40
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 clear

--- a/init-voyager-mariadb/prompt.sh
+++ b/init-voyager-mariadb/prompt.sh
@@ -11,6 +11,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 EXPORT_DIR="/workspaces/ybdb-vanguard/init-voyager-mariadb/voyager-data"

--- a/init-voyager-mysql/prompt.sh
+++ b/init-voyager-mysql/prompt.sh
@@ -17,6 +17,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 EXPORT_DIR="/workspaces/ybdb-vanguard/init-voyager-mysql/voyager-data"

--- a/init-voyager-oracle/prompt.sh
+++ b/init-voyager-oracle/prompt.sh
@@ -14,6 +14,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 EXPORT_DIR="/workspaces/ybdb-vanguard/init-voyager-oracle/voyager-data"

--- a/init-voyager-postgres/prompt.sh
+++ b/init-voyager-postgres/prompt.sh
@@ -19,6 +19,10 @@ set -f  # disable filename expansion — prevents SELECT * glob-expanding in eva
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 # Use the absolute path set in devcontainer containerEnv.

--- a/init-xcluster/prompt.sh
+++ b/init-xcluster/prompt.sh
@@ -27,6 +27,10 @@
 
 TYPE_SPEED=35
 NO_WAIT=false
+# Each `pe` normally pauses TWICE (before typing the command, and again before
+# running it). This removes the first pause so the command types out as soon as
+# you reach it; you then press Enter ONCE to run it. One pause per step.
+NO_WAIT_DISPLAY_CMD=true
 DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
 
 SRC="127.0.0.1"


### PR DESCRIPTION
## Summary

Each `pe` call in demo-magic waits for Enter **twice** — once before typing the command and once before running it — which doubled the keypresses needed to step through every guided demo.

This sets `NO_WAIT_DISPLAY_CMD=true` in all 20 `prompt.sh` scripts so the command types out immediately and a single Enter runs it. **One pause per step instead of two.**

## Changes

- Added `NO_WAIT_DISPLAY_CMD=true` to the demo-magic config block in all `init-*/prompt.sh` scripts (20 files).

## Test plan

- [ ] Run a guided demo (e.g. `init-cdc/prompt.sh`) and confirm each command requires a single Enter to advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)